### PR TITLE
[bugfix] deepflow querier datasource, variables query sql is wrong

### DIFF
--- a/deepflow-querier-datasource/src/datasource.ts
+++ b/deepflow-querier-datasource/src/datasource.ts
@@ -739,7 +739,7 @@ export class DataSource extends DataSourceApi<MyQuery, MyDataSourceOptions> {
         ...params,
         ...(datasource
           ? {
-              datasource
+              data_precision: datasource
             }
           : undefined)
       }


### PR DESCRIPTION
**Phenomenon and reproduction steps**

none

**Root cause and solution**

- api filed 'datasouce' has changed to 'data_precision'

**Impactions**

none

**Test method**

none

**Affected branch(es)**

- v6.1

**Checklist**

- [ ] Dependencies update required
- [ ] Common bug (similar problem in other repo)