### PR TITLE
bump grafana-clickhouse-datasource to v2.2.1

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -98,19 +98,19 @@ jobs:
       - uses: robinraju/release-downloader@v1.4
         with:
           repository: "grafana/clickhouse-datasource"
-          tag: "v2.0.5"
-          fileName: "grafana-clickhouse-datasource-2.0.5.linux_arm64.zip"
+          tag: "v2.2.1"
+          fileName: "grafana-clickhouse-datasource-2.2.1.linux_arm64.zip"
 
       - uses: robinraju/release-downloader@v1.4
         with:
           repository: "grafana/clickhouse-datasource"
-          tag: "v2.0.5"
-          fileName: "grafana-clickhouse-datasource-2.0.5.linux_amd64.zip"
+          tag: "v2.2.1"
+          fileName: "grafana-clickhouse-datasource-2.2.1.linux_amd64.zip"
 
       - name: Unzip grafana-clickhouse-datasource
         run: |
-          unzip -d plugin-amd64 grafana-clickhouse-datasource-2.0.5.linux_amd64.zip
-          unzip -d plugin-arm64 grafana-clickhouse-datasource-2.0.5.linux_arm64.zip
+          unzip -d plugin-amd64 grafana-clickhouse-datasource-2.2.1.linux_amd64.zip
+          unzip -d plugin-arm64 grafana-clickhouse-datasource-2.2.1.linux_arm64.zip
 
       - name: Log In To GitHub Docker Registry
         uses: docker/login-action@v2


### PR DESCRIPTION
Fix the following CVEs:

```json
[
  {
    "Target": "deepflow-plugins/grafana-clickhouse-datasource/gpx_clickhouse_linux_amd64",
    "VulnerabilityID": "CVE-2022-27664",
    "Severity": "HIGH",
    "PkgName": "golang.org/x/net",
    "InstalledVersion": "v0.0.0-20220617184016-355a448f1bc9",
    "FixedVersion": "0.0.0-20220906165146-f3363e06e74c"
  },
  {
    "Target": "deepflow-plugins/grafana-clickhouse-datasource/gpx_clickhouse_linux_amd64",
    "VulnerabilityID": "CVE-2022-41721",
    "Severity": "HIGH",
    "PkgName": "golang.org/x/net",
    "InstalledVersion": "v0.0.0-20220617184016-355a448f1bc9",
    "FixedVersion": "0.1.1-0.20221104162952-702349b0e862"
  },
  {
    "Target": "deepflow-plugins/grafana-clickhouse-datasource/gpx_clickhouse_linux_amd64",
    "VulnerabilityID": "CVE-2022-41723",
    "Severity": "HIGH",
    "PkgName": "golang.org/x/net",
    "InstalledVersion": "v0.0.0-20220617184016-355a448f1bc9",
    "FixedVersion": "0.7.0"
  },
  {
    "Target": "deepflow-plugins/grafana-clickhouse-datasource/gpx_clickhouse_linux_amd64",
    "VulnerabilityID": "CVE-2022-32149",
    "Severity": "HIGH",
    "PkgName": "golang.org/x/text",
    "InstalledVersion": "v0.3.7",
    "FixedVersion": "0.3.8"
  }
]
```