### PR TITLE
[bugfix] Json convert error at grafana Alert

### DIFF
--- a/deepflow-querier-datasource/src/utils/genQueryParams.ts
+++ b/deepflow-querier-datasource/src/utils/genQueryParams.ts
@@ -531,8 +531,11 @@ export function genQueryParams(queryData: Record<any, any>, scopedVars: ScopedVa
 
 export const replaceIntervalAndVariables = (queryText: string, scopedVars?: ScopedVars) => {
   let _queryText = queryText
-    .replace(`"${TIME_VARIABLE_FROM}"`, TIME_VARIABLE_FROM)
-    .replace(`"${TIME_VARIABLE_TO}"`, TIME_VARIABLE_TO)
+  if ((getTemplateSrv() as any).timeRange) {
+    _queryText = queryText
+      .replace(`"${TIME_VARIABLE_FROM}"`, TIME_VARIABLE_FROM)
+      .replace(`"${TIME_VARIABLE_TO}"`, TIME_VARIABLE_TO)
+  }
   if (typeof scopedVars?.__interval_ms?.value === 'number') {
     const intervalSecond = scopedVars.__interval_ms.value / 1000
     _queryText = queryText


### PR DESCRIPTION
解决 Grafana 告警界面的 JSON 反序列化错误的问题。
针对Grafana 告警界面没有 timeRange的情况下，不对timeRange变量做替换处理