### PR TITLE
[bugfix] remove svg namespace from jest mocks

### DIFF
--- a/deepflow-apptracing-panel/.config/jest/mocks/react-inlinesvg.tsx
+++ b/deepflow-apptracing-panel/.config/jest/mocks/react-inlinesvg.tsx
@@ -19,7 +19,7 @@ const SVG_FILE_NAME_REGEX = /(.+)\/(.+)\.svg$/;
 const InlineSVG = ({ src }: { src: string }) => {
   // testId will be the file name without extension (e.g. `public/img/icons/angle-double-down.svg` -> `angle-double-down`)
   const testId = src.replace(SVG_FILE_NAME_REGEX, '$2');
-  return <svg xmlns="http://www.w3.org/2000/svg" data-testid={testId} viewBox="0 0 24 24" />;
+  return <svg data-testid={testId} viewBox="0 0 24 24" />;
 };
 
 export default InlineSVG;

--- a/deepflow-querier-datasource/.config/jest/mocks/react-inlinesvg.tsx
+++ b/deepflow-querier-datasource/.config/jest/mocks/react-inlinesvg.tsx
@@ -19,7 +19,7 @@ const SVG_FILE_NAME_REGEX = /(.+)\/(.+)\.svg$/;
 const InlineSVG = ({ src }: { src: string }) => {
   // testId will be the file name without extension (e.g. `public/img/icons/angle-double-down.svg` -> `angle-double-down`)
   const testId = src.replace(SVG_FILE_NAME_REGEX, '$2');
-  return <svg xmlns="http://www.w3.org/2000/svg" data-testid={testId} viewBox="0 0 24 24" />;
+  return <svg data-testid={testId} viewBox="0 0 24 24" />;
 };
 
 export default InlineSVG;

--- a/deepflow-topo-panel/.config/jest/mocks/react-inlinesvg.tsx
+++ b/deepflow-topo-panel/.config/jest/mocks/react-inlinesvg.tsx
@@ -19,7 +19,7 @@ const SVG_FILE_NAME_REGEX = /(.+)\/(.+)\.svg$/;
 const InlineSVG = ({ src }: { src: string }) => {
   // testId will be the file name without extension (e.g. `public/img/icons/angle-double-down.svg` -> `angle-double-down`)
   const testId = src.replace(SVG_FILE_NAME_REGEX, '$2');
-  return <svg xmlns="http://www.w3.org/2000/svg" data-testid={testId} viewBox="0 0 24 24" />;
+  return <svg data-testid={testId} viewBox="0 0 24 24" />;
 };
 
 export default InlineSVG;


### PR DESCRIPTION
**Phenomenon and reproduction steps**

Security scanning flagged `http://www.w3.org/2000/svg` in the Jest `react-inlinesvg` mock files of `deepflow-apptracing-panel`, `deepflow-querier-datasource`, and `deepflow-topo-panel` as HTTP plaintext transmission risk.

**Root cause and solution**

The flagged string came from the `xmlns` namespace attribute in test-only mock SVG elements rather than any runtime network request. Remove the unnecessary `xmlns` attribute from the three Jest mock files to avoid false-positive HTTP findings while keeping the mock behavior unchanged.

**Impactions**

The Jest SVG mocks no longer contain the HTTP namespace string, which reduces false-positive vulnerability findings in these plugin packages. Runtime behavior is unchanged because the modified files are only used in tests.

**Test method**

Run `rg -n "http://www\.w3\.org/2000/svg" deepflow-apptracing-panel/.config/jest/mocks deepflow-querier-datasource/.config/jest/mocks deepflow-topo-panel/.config/jest/mocks` and confirm there is no match.

**Affected branch(es)**

* main

**Checklist**

- [ ] Dependencies update required
- [ ] Common bug (similar problem in other repo)